### PR TITLE
fix: limit token scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,11 @@ require it in your namespace:
 ```clojure
 (qiniu/uptoken bucket)
 (qiniu/uptoken bucket
-	:expires 3600
+    :expires 3600
     :key "photo/my.jpg" ;; limit scope to key or a prefix
-	:callbackUrl "http://exmaple.com/callback"
-	:insertOnly 1
-	:detectMime 1)
+    :callbackUrl "http://exmaple.com/callback"
+    :insertOnly 1
+    :detectMime 1)
 ```
 
 更多选项直接看源码吧。

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ require it in your namespace:
 (qiniu/uptoken bucket)
 (qiniu/uptoken bucket
 	:expires 3600
-	:scope scope
+    :key "photo/my.jpg" ;; limit scope to key or a prefix
 	:callbackUrl "http://exmaple.com/callback"
 	:insertOnly 1
 	:detectMime 1)

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject cn.leancloud/clj.qiniu "0.2.2"
+(defproject cn.leancloud/clj.qiniu "0.3.0"
   :description "Clojure SDK for qiniu.com storage."
   :url "https://github.com/leancloud/clj.qiniu"
   :license {:name "Eclipse Public License"

--- a/src/clj/qiniu.clj
+++ b/src/clj/qiniu.clj
@@ -74,13 +74,24 @@
   (Auth/create (or access-key @ACCESS-KEY) (or secret-key @SECRET-KEY)))
 
 (defn uptoken
-  "Create a uptoken for uploading file. see http://developer.qiniu.com/docs/v6/sdk/java-sdk.html#make-uptoken"
-  [bucket & {:keys [access-key secret-key expires mimeLimit persistentOps detectMime deadline endUser isPrefixalScope fsizeMin callbackBodyType returnBody saveKey callbackHost persistentPipeline callbackBody scope fileType persistentNotifyUrl fsizeLimit insertOnly returnUrl callbackUrl] :as opts :or {expires 3600}}]
+  "Create a uptoken for uploading file.
+
+  :key             - A file key or prefix used to limit the token scope.
+                     Leave it as nil if no limit on scope.
+  :isPrefixalScope - whether the key should be a prefix or not.
+
+  see http://developer.qiniu.com/docs/v6/sdk/java-sdk.html#make-uptoken"
+  [bucket & {:keys [access-key secret-key expires mimeLimit persistentOps
+                    detectMime deadline endUser isPrefixalScope fsizeMin
+                    callbackBodyType returnBody saveKey callbackHost
+                    persistentPipeline callbackBody key fileType
+                    persistentNotifyUrl fsizeLimit insertOnly returnUrl
+                    callbackUrl] :as opts :or {expires 3600}}]
   (let [auth (create-auth opts)
         ^StringMap sm (StringMap.)]
-    (doseq [[k v] opts]
+    (doseq [[k v] (dissoc opts :key)]
       (.put sm (name k) v))
-    (.uploadToken auth bucket nil expires sm true)))
+    (.uploadToken auth bucket key expires sm true)))
 
 (defn- map->string-map
   [m]

--- a/test/clj/qiniu_test.clj
+++ b/test/clj/qiniu_test.clj
@@ -34,11 +34,11 @@
 (deftest test-uptoken
   (testing "uptoken"
     (is (uptoken test-bucket :expires 10))
-    (is (uptoken test-bucket :expires 10 :scope test-bucket))
-    (is (uptoken test-bucket :expires 10 :scope test-bucket :callbackUrl "http://localhost"))
-    (is (uptoken test-bucket :expires 10 :scope test-bucket :callbackUrl "http://localhost" :detectMime 1))
-    (is (uptoken test-bucket :expires 10 :scope test-bucket  :callbackUrl "http://localhost" :detectMime 1 :insertOnly 1))
-    (is (uptoken test-bucket :expires 10 :scope test-bucket  :callbackUrl "http://localhost" :detectMime 1 :insertOnly 1 :fsizeLimit (* 1024 1024)))))
+    (is (uptoken test-bucket :expires 10 :key "photos" :isPrefixalScope true))
+    (is (uptoken test-bucket :expires 10 :key "photos/my.jpg" :callbackUrl "http://localhost"))
+    (is (uptoken test-bucket :expires 10 :key "my.jpg" :callbackUrl "http://localhost" :detectMime 1))
+    (is (uptoken test-bucket :expires 10 :key "my.jpg"  :callbackUrl "http://localhost" :detectMime 1 :insertOnly 1))
+    (is (uptoken test-bucket :expires 10 :key test-bucket  :callbackUrl "http://localhost" :detectMime 1 :insertOnly 1 :fsizeLimit (* 1024 1024)))))
 
 (deftest test-upload
   (testing "upload"

--- a/test/clj/qiniu_test.clj
+++ b/test/clj/qiniu_test.clj
@@ -1,7 +1,9 @@
 (ns clj.qiniu-test
-  (:import [java.io StringReader])
+  (:import [java.util Base64]
+           [java.io StringReader])
   (:require [clojure.test :refer :all]
             [clojure.string :as cstr]
+            [cheshire.core :as json]
             [clojure.java.io :as io]
             [clj.qiniu :refer :all]))
 
@@ -31,10 +33,25 @@
       (is (= test-secret (:SECRET-KEY config)))
       (is (= "Clojure/qiniu sdk 1.0" (:USER-AGENT config))))))
 
+(defn decode-base64 [to-decode]
+  (String. (.decode (java.util.Base64/getDecoder) to-decode)))
+
+(defn- decode-token-json
+  "Deocode uptoken into a policy map."
+  [token]
+  (-> (cstr/split (or token "") #":")
+      (last)
+      (decode-base64)
+      (json/parse-string true)))
+
 (deftest test-uptoken
   (testing "uptoken"
+    (is (-> (uptoken test-bucket :key "photos" :isPrefixalScope true)
+            (decode-token-json)
+            (dissoc :deadline)
+            (= {:scope (str test-bucket ":photos")
+                :isPrefixalScope true})))
     (is (uptoken test-bucket :expires 10))
-    (is (uptoken test-bucket :expires 10 :key "photos" :isPrefixalScope true))
     (is (uptoken test-bucket :expires 10 :key "photos/my.jpg" :callbackUrl "http://localhost"))
     (is (uptoken test-bucket :expires 10 :key "my.jpg" :callbackUrl "http://localhost" :detectMime 1))
     (is (uptoken test-bucket :expires 10 :key "my.jpg"  :callbackUrl "http://localhost" :detectMime 1 :insertOnly 1))


### PR DESCRIPTION
由于官方 java-sdk 并没有尊重 putPolicy 中的 `scope`参数，因此只能通过 `key` 来限制 scope.

https://github.com/qiniu/java-sdk/blob/944085706746b6eec2dc6342cdf3d693d403dc5e/src/main/java/com/qiniu/util/Auth.java#L364